### PR TITLE
Fix issue with apcu extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 	],
 	"require" : {
 		"php" : ">=5.3.0",
-		"doctrine/cache" : "~1.4",
+		"doctrine/cache" : "~1.6",
 		"mouf/utils.constants.debug" : "~1.0",
 		"mouf/utils.constants.secret" : "~1.0",
 		"mouf/utils.cache.cache-interface" : "~2.0"

--- a/src/CacheInstaller.php
+++ b/src/CacheInstaller.php
@@ -29,7 +29,7 @@ if (DEBUG) {
 } else {
 	// If APC is available, let\'s use APC
 	if (extension_loaded("apc") || extension_loaded("apcu")) {
-		$driver = new \\Doctrine\\Common\\Cache\\ApcCache();
+		$driver = new \\Doctrine\\Common\\Cache\\ApcuCache();
 	} else {
 		$driver = new \\Doctrine\\Common\\Cache\\FileCache(sys_get_temp_dir().\'/doctrinecache\');
 	}

--- a/src/CacheInstaller.php
+++ b/src/CacheInstaller.php
@@ -28,7 +28,7 @@ if (DEBUG) {
 	$driver = new \\Doctrine\\Common\\Cache\\ArrayCache();
 } else {
 	// If APC is available, let\'s use APC
-	if (extension_loaded("apc")) {
+	if (extension_loaded("apc") || extension_loaded("apcu")) {
 		$driver = new \\Doctrine\\Common\\Cache\\ApcCache();
 	} else {
 		$driver = new \\Doctrine\\Common\\Cache\\FileCache(sys_get_temp_dir().\'/doctrinecache\');

--- a/src/CacheInstaller.php
+++ b/src/CacheInstaller.php
@@ -28,7 +28,7 @@ if (DEBUG) {
 	$driver = new \\Doctrine\\Common\\Cache\\ArrayCache();
 } else {
 	// If APC is available, let\'s use APC
-	if (extension_loaded("apc") || extension_loaded("apcu")) {
+	if (extension_loaded("apcu")) {
 		$driver = new \\Doctrine\\Common\\Cache\\ApcuCache();
 	} else {
 		$driver = new \\Doctrine\\Common\\Cache\\FileCache(sys_get_temp_dir().\'/doctrinecache\');

--- a/src/CacheInstaller.php
+++ b/src/CacheInstaller.php
@@ -30,6 +30,8 @@ if (DEBUG) {
 	// If APC is available, let\'s use APC
 	if (extension_loaded("apcu")) {
 		$driver = new \\Doctrine\\Common\\Cache\\ApcuCache();
+	} else if (extension_loaded("apc")) {
+		$driver = new \\Doctrine\\Common\\Cache\\ApcCache();
 	} else {
 		$driver = new \\Doctrine\\Common\\Cache\\FileCache(sys_get_temp_dir().\'/doctrinecache\');
 	}


### PR DESCRIPTION
Let's now check for the extension "apcu" for php 7.

TODO : The class FileCache is now an abstract class so we cant' instantiate it directly.
